### PR TITLE
Fixed regression in argument validation in command-line mode.

### DIFF
--- a/GeckoLoader.py
+++ b/GeckoLoader.py
@@ -200,9 +200,9 @@ class GeckoLoaderCli(CommandLineParser):
         if args.dest:
             dest = Path(args.dest).resolve()
             if dest.suffix == "":
-                dest = dest / args.dolfile.name
+                dest = dest / dolFile.name
         else:
-            dest = Path.cwd() / "geckoloader-build" / args.dolfile.name
+            dest = Path.cwd() / "geckoloader-build" / dolFile.name
 
         if args.alloc:
             try:


### PR DESCRIPTION
Regression introduced as part of https://github.com/JoshuaMKW/GeckoLoader/commit/8e1bd5d38b45152cd41fda36f1917b2f4fec44f3.

The filepath to the DOL file provided in the positional `dolfile`
argument was being resolved as a `pathlib.Path` object, but then the
original string variable (a less rich type) was still being used wrongly
to retrive a non-existing `name` attribute.

For example:
```bash
python3 GeckoLoader.py /path/to/main.dol /path/to/GM4E01.gct
```

Which would produce:
```python
Traceback (most recent call last):
  File "GeckoLoader.py", line 898, in <module>
    cli._exec(args, TMPDIR)
  File "GeckoLoader.py", line 261, in _exec
    context = self._validate_args(args)
  File "GeckoLoader.py", line 205, in _validate_args
    dest = Path.cwd() / "geckoloader-build" / args.dolfile.name
AttributeError: 'str' object has no attribute 'name'
```